### PR TITLE
Add support for CukeModeler 3.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ gemfile:
   - gemfiles/cuke_modeler0.gemfile
   - gemfiles/cuke_modeler1.gemfile
   - gemfiles/cuke_modeler2.gemfile
+  - gemfiles/cuke_modeler3.gemfile
 
 matrix:
   exclude:
@@ -24,6 +25,9 @@ matrix:
     # Ruby 2.3.x for OSX is currently broken on TravisCI and is no longer a supported Ruby version, anyway.
     - rvm: 2.3.8
       os: osx
+    # cuke_modeler 3.x has a minimum Ruby version of 2.3
+    - rvm: 1.9.3
+      gemfile: gemfiles/cuke_modeler3.gemfile
 
 
 script: bundle exec rake cuke_slicer:ci_build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-Nothing yet...
-
+### Added
+ - Added support for `cuke_modeler` 2.x and 3.x
 
 ## [2.0.3] - 2019-05-01
 

--- a/cuke_slicer.gemspec
+++ b/cuke_slicer.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 1.9.3', '< 3.0'
 
-  spec.add_runtime_dependency "cuke_modeler", "< 3.0"
+  spec.add_runtime_dependency "cuke_modeler", "< 4.0"
 
   spec.add_development_dependency 'bundler', '< 3.0'
   spec.add_development_dependency 'rake', '< 13.0.0'

--- a/gemfiles/cuke_modeler0.gemfile
+++ b/gemfiles/cuke_modeler0.gemfile
@@ -12,4 +12,6 @@ if RUBY_VERSION =~ /^1\./
   gem 'json', '< 2.0' # The 'json' gem drops pre-Ruby 2.x support on/after this version
   gem 'tins', '< 1.7' # The 'tins' gem requires Ruby 2.x on/after this version
   gem 'term-ansicolor', '< 1.4' # The 'term-ansicolor' gem requires Ruby 2.x on/after this version
+else
+  gem 'cucumber', '< 4.0.0' # Cucumber 4.x switches to needing the `cucumber-gherkin` gem, which is incompatible with `cuke_modeler` 0.x
 end

--- a/gemfiles/cuke_modeler1.gemfile
+++ b/gemfiles/cuke_modeler1.gemfile
@@ -10,4 +10,6 @@ if RUBY_VERSION =~ /^1\./
   gem 'json', '< 2.0' # The 'json' gem drops pre-Ruby 2.x support on/after this version
   gem 'tins', '< 1.7' # The 'tins' gem requires Ruby 2.x on/after this version
   gem 'term-ansicolor', '< 1.4' # The 'term-ansicolor' gem requires Ruby 2.x on/after this version
+else
+  gem 'cucumber', '< 4.0.0' # Cucumber 4.x switches to needing the `cucumber-gherkin` gem, which is incompatible with `cuke_modeler` 1.x
 end

--- a/gemfiles/cuke_modeler2.gemfile
+++ b/gemfiles/cuke_modeler2.gemfile
@@ -10,4 +10,6 @@ if RUBY_VERSION =~ /^1\./
   gem 'json', '< 2.0' # The 'json' gem drops pre-Ruby 2.x support on/after this version
   gem 'tins', '< 1.7' # The 'tins' gem requires Ruby 2.x on/after this version
   gem 'term-ansicolor', '< 1.4' # The 'term-ansicolor' gem requires Ruby 2.x on/after this version
+else
+  gem 'cucumber', '< 4.0.0' # Cucumber 4.x switches to needing the `cucumber-gherkin` gem, which is incompatible with `cuke_modeler` 2.x
 end

--- a/gemfiles/cuke_modeler3.gemfile
+++ b/gemfiles/cuke_modeler3.gemfile
@@ -1,0 +1,6 @@
+source 'https://rubygems.org'
+
+gemspec :path => "../"
+
+gem 'cuke_modeler', '~> 3.0'
+

--- a/gemfiles/cuke_modeler3.gemfile
+++ b/gemfiles/cuke_modeler3.gemfile
@@ -4,3 +4,8 @@ gemspec :path => "../"
 
 gem 'cuke_modeler', '~> 3.0'
 
+gem 'cucumber', '2.2.0' # `cucumber` 4.x does not currently work on JRuby
+
+if RUBY_VERSION =~ /^2\.[1234]/
+  gem 'activesupport', '< 6.0' # `activesupport` 6.x requires at least Ruby 2.5
+end

--- a/lib/cuke_slicer/helpers/matching_helpers.rb
+++ b/lib/cuke_slicer/helpers/matching_helpers.rb
@@ -29,7 +29,7 @@ module CukeSlicer
 
     def filter_match(element, filter)
       tag_values = element.all_tags
-      tag_values = tag_values.collect { |tag| tag.name } if Gem.loaded_specs['cuke_modeler'].version.version[/^[12]/]
+      tag_values = tag_values.collect { |tag| tag.name } unless Gem.loaded_specs['cuke_modeler'].version.version[/^[0]/]
 
       if filter.is_a?(Regexp)
         tag_values.any? { |tag| tag =~ filter }


### PR DESCRIPTION
Upgraded the gem so that it is compatible with `cuke_modeler` 3.x.